### PR TITLE
Fix 'preact build' failures with *.tsx files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "preact-cli-plugin-typescript",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -534,6 +534,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
+    },
+    "colour": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
+      "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g="
     },
     "commander": {
       "version": "2.9.0",
@@ -3688,14 +3693,6 @@
         }
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -3712,6 +3709,14 @@
       "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.0.tgz",
       "integrity": "sha1-aybpvTr8qnvjtCabUm3huCAArHg=",
       "dev": true
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -3904,6 +3909,34 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.1.tgz",
       "integrity": "sha1-w8yxbdqgsjFN4DHn5v7onlujRrw="
+    },
+    "typings-for-css-modules-loader": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/typings-for-css-modules-loader/-/typings-for-css-modules-loader-1.7.0.tgz",
+      "integrity": "sha512-Mp7zDrcUmbUKl3JTLamTsMX+lntMotEm5I05j2RHB5EHb0WL1dAXlynpdlGR5Ye/QTvtL5w+RGB2jP32YoUpZw==",
+      "requires": {
+        "colour": "0.7.1",
+        "graceful-fs": "4.1.4",
+        "loader-utils": "0.2.16"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
+          "integrity": "sha1-7widKIDwM7ARgjzlyPrnmNp3Xb0="
+        },
+        "loader-utils": {
+          "version": "0.2.16",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz",
+          "integrity": "sha1-8IYyBm7YKCg13/iN+1JwR2Wt7m0=",
+          "requires": {
+            "big.js": "3.1.3",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1",
+            "object-assign": "4.1.1"
+          }
+        }
+      }
     },
     "union-value": {
       "version": "0.2.4",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "dependencies": {
     "awesome-typescript-loader": "^3.2.1",
-    "typescript": "^2.4.1"
+    "typescript": "^2.4.1",
+    "typings-for-css-modules-loader": "^1.7.0"
   },
   "devDependencies": {
     "eslint": "^3.19.0",

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,37 @@ const preactCliTypeScript = config => {
   // resolved by webpack. This can be overridden by the user.
   config.resolve.alias['preact-cli-entrypoint'] = resolve(process.cwd(), 'src', 'index')
 
+  // Recursively substitute 'typings-for-css-modules-loader' for 'css-loader'
+  // when generating CSS modules.  'typings-for-css-modules-loader' generates
+  // '*.d.ts' files, allowing CSS modules to be imported in *.tsx files via:
+  //
+  //    import * as style from './style.css';
+  //
+  // (See https://github.com/wub/preact-cli-plugin-typescript/issues/4)
+  const substituteTypingsForCssModulesLoader = config => {
+    // Match instances of { loader: 'css-loader', options { modules: true }}
+    if (config.loader === 'css-loader'
+      && config.options
+      && config.options.modules) {
+      config.loader = 'typings-for-css-modules-loader';
+
+      // Use of 'namedExport' and 'camelCase' are required:
+      // https://github.com/Jimdo/typings-for-css-modules-loader/issues/20#issuecomment-334867043
+      config.options.namedExport = true;
+      config.options.camelCase = true;
+    }
+
+    // Recursively search for and replace instances of 'css-loader' per the above.
+    for (const key of Object.keys(config)) {
+      const value = config[key];
+      if (typeof value === "object") {
+        substituteTypingsForCssModulesLoader(value);
+      }
+    }
+  };
+
+  substituteTypingsForCssModulesLoader(config);
+
   return config
 }
 

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "target": "es2017",
+    "target": "es5",
+    "lib": [ "esnext", "dom" ],
     "module": "esnext",
     "moduleResolution": "node",
     "sourceMap": true,


### PR DESCRIPTION
Fix the module errors in #2 and #3 by defaulting tsconfig.json to emit 'ES5'.
Fix the original issue w/CSS Modules in #4 by including 'typings-for-css-modules-loader'.